### PR TITLE
Add Kalmix GNSS Handbook to Blogs

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ CGGTTS is used in remote clock comparison, by mean of common satellite vehicle i
 ### Blogs
 
 - [BlackDotGNSS](https://www.blackdotgnss.com/blog/) - Technical discussions related to GNSS data processing.
+- [Kalmix GNSS Handbook](https://www.kalmixtech.com/blogs/blog/tagged/gnss-handbook) - Practical engineering notes on GNSS fundamentals, pseudorange, signal bands, RTCM/NTRIP correction workflows, NMEA 0183, and coordinate systems for RTK integration.
 - [rtklibexplorer](https://rtklibexplorer.wordpress.com/) - Using RTKLIB for precise positioning with low-cost GNSS receivers.
 
 ### Wikis


### PR DESCRIPTION
Hi, thanks for maintaining this GNSS resource list.

This PR adds the Kalmix GNSS Handbook to the Blogs section. It is a free engineering series covering GNSS fundamentals, pseudorange, satellite geometry, L1/L2/L5 signal bands, RTCM/NTRIP correction workflows, NMEA 0183, and coordinate-system issues for RTK integration.

I added the tagged series page rather than a product page, so the link points to the educational GNSS/RTK resource collection.
